### PR TITLE
Nur Status der letzten 7 Tage und Nachrichten, die dazu passen

### DIFF
--- a/status.rb
+++ b/status.rb
@@ -71,7 +71,7 @@ class StatusApp < Sinatra::Base
         d["door_open"] = state
       end
     end
-    
+
     @data.reverse!
 
     statusS = Array.new status


### PR DESCRIPTION
Aktuell sind es einfach 10 Statusänderungen und 10 Nachrichten. Wenn also eine Zeit lang nichts geschrieben wurde, dann dümpeln unten ein paar Nachrichten ohne Bezug rum, aktuell auf http://nobreakspace.org/status/
Jetzt werden sich die Statusänderungen der letzten 7 Tage geholt und nur Nachrichten, die neuer als die älteste Statusänderung sind.
Ausserdem: fix whitespace & Timezone
