### PR TITLE
Höheres Limit für messages

### DIFF
--- a/status.rb
+++ b/status.rb
@@ -28,7 +28,7 @@ class StatusApp < Sinatra::Base
     end
     def getmessages(status)
       # und nur Messages, die zu den gefundenen Status passen
-      messages = DB.execute("SELECT * FROM messages WHERE timestamp > ? ORDER BY timestamp LIMIT 20", status[-1]["timestamp"])
+      messages = DB.execute("SELECT * FROM messages WHERE timestamp > ? ORDER BY timestamp LIMIT 200", status[-1]["timestamp"])
       return messages
     end
     def getdata(status, messages)


### PR DESCRIPTION
Messages sind schon durch den timestamp beschränkt, ein Limit von 20 ist etwas wenig, wenn die Woche mehr geschrieben wurde. Wir sollten das eher "zur Sicherheit" limitieren, wenn überhaupt.
