### PR TITLE
Making the spaceapi compliant to the new 0.13 specification

### DIFF
--- a/status.rb
+++ b/status.rb
@@ -153,7 +153,7 @@ class StatusApp < Sinatra::Base
       if d != nil and dPrev != nil
         if d['door_open'] != dPrev['door_open']
           start = d['timestamp']
-          @lastchange = Time.parse(start + " UTC").to_i
+          @lastchange = start;
           break
         end
       end
@@ -166,8 +166,8 @@ class StatusApp < Sinatra::Base
     end
 
     json = YAML.load_file('status.yml')
-    json[:open] = @open
-    json[:lastchange] = @lastchange
+    json['state'][:open]= @open
+    json['state'][:lastchange] = @lastchange
 
     content_type 'application/json'
     jsonp json

--- a/status.rb
+++ b/status.rb
@@ -153,7 +153,7 @@ class StatusApp < Sinatra::Base
       if d != nil and dPrev != nil
         if d['door_open'] != dPrev['door_open']
           start = d['timestamp']
-          @lastchange = Time.parse(start + "UTC")
+          @lastchange = Time.parse(start + "UTC").localtime.strftime("%s").to_i
           break
         end
       end

--- a/status.rb
+++ b/status.rb
@@ -80,7 +80,7 @@ class StatusApp < Sinatra::Base
     (statusS.zip status).each do |d, dPrev|
       if d != nil and dPrev != nil
         if d['door_open'] != dPrev['door_open']
-          start = d['timestamp'] + " UTC"
+          start = Time.parse(d['timestamp'] + "UTC").localtime
           @duration = Time.diff(Time.now(), start, '%h:%m')[:diff]
           break
         end
@@ -153,7 +153,7 @@ class StatusApp < Sinatra::Base
       if d != nil and dPrev != nil
         if d['door_open'] != dPrev['door_open']
           start = d['timestamp']
-          @lastchange = start;
+          @lastchange = Time.parse(start + "UTC").localtime
           break
         end
       end

--- a/status.rb
+++ b/status.rb
@@ -80,7 +80,7 @@ class StatusApp < Sinatra::Base
     (statusS.zip status).each do |d, dPrev|
       if d != nil and dPrev != nil
         if d['door_open'] != dPrev['door_open']
-          start = Time.parse(d['timestamp'] + "UTC").localtime
+          start = Time.parse(d['timestamp'] + "UTC")
           @duration = Time.diff(Time.now(), start, '%h:%m')[:diff]
           break
         end
@@ -153,7 +153,7 @@ class StatusApp < Sinatra::Base
       if d != nil and dPrev != nil
         if d['door_open'] != dPrev['door_open']
           start = d['timestamp']
-          @lastchange = Time.parse(start + "UTC").localtime
+          @lastchange = Time.parse(start + "UTC")
           break
         end
       end

--- a/status.yml
+++ b/status.yml
@@ -1,21 +1,23 @@
-api: "0.12"
+api: "0.13"
 space: MetaMeute
 url: https://metameute.de
-icon:
-  open: http://status.metameute.de/images/open.png
-  closed: http://status.metameute.de/images/closed.png
-address: Unversität zu Lübeck, Gebäude 62, Ratzeburger Allee 160, 23562 Lübeck, Germany
+state:
+  icon:
+    open: http://status.metameute.de/images/open.png
+    closed: http://status.metameute.de/images/closed.png
 contact:
   phone: "+494515005011"
-  ml: MetaMeute@asta.uni-luebeck.de
+  email: metameute@asta.uni-luebeck.de
+  ml: metameute@asta.uni-luebeck.de
   irc: irc://irc.oftc.net/#Metameute
 logo: http://status.metameute.de/images/logo.png
 feeds:
-  - name: blog
-    type: application/rss+xml
-    url: http://blog.metameute.de/feed/
-  - name: status
-    type: application/rss+xml
-    url: http://status.metameute.de/rss
-lat: 53.834372
-lon: 10.702268
+    blog:
+      type: application/rss+xml
+      url: http://blog.metameute.de/feed/
+issue_report_channels:
+  - email
+location:
+    lat: 53.834372
+    lon: 10.702268
+    address: Unversität zu Lübeck, Gebäude 62, Ratzeburger Allee 160, 23562 Lübeck, Germany

--- a/views/index.erb
+++ b/views/index.erb
@@ -31,7 +31,7 @@
   %>
     <% if d.has_key? "message" %>
     <li class="message <% if d['door_open'].to_i == 1 %>open<% else %>closed<% end %>">
-      <span class="time"><%= Time.parse(d['timestamp'] + "UTC").localtime.strftime("%Y-%m-%d %H:%M") %></span>
+      <span class="time"><%= Time.at(d['timestamp']).localtime.strftime("%Y-%m-%d %H:%M") %></span>
       <%= h d['message'] %>
     <% else %>
     <li class="status <% if d['door_open'].to_i == 1 %>open<% else %>closed<% end %>">
@@ -40,13 +40,13 @@
       <% else %>
         geschlossen
       <% end %>
-      <span class="time"><%= Time.parse(d['timestamp'] + "UTC").localtime.strftime("%Y-%m-%d %H:%M") %></span>
+      <span class="time"><%= Time.at(d['timestamp']).localtime.strftime("%Y-%m-%d %H:%M") %></span>
     <% end %>
     </li>
   <% end %>
 </ul>
 
 <footer>
-  <a href="https://github.com/MetaMeute/metameutestatus">Source Code</a> // 
+  <a href="https://github.com/MetaMeute/metameutestatus">Source Code</a> //
   <a href="<%= url('/rss') %>">RSS</a>
 </footer>

--- a/views/index.erb
+++ b/views/index.erb
@@ -31,7 +31,7 @@
   %>
     <% if d.has_key? "message" %>
     <li class="message <% if d['door_open'].to_i == 1 %>open<% else %>closed<% end %>">
-      <span class="time"><%= Time.at(d['timestamp']).localtime.strftime("%Y-%m-%d %H:%M") %></span>
+      <span class="time"><%= Time.parse(d['timestamp'] + "UTC").localtime.strftime("%Y-%m-%d %H:%M") %></span>
       <%= h d['message'] %>
     <% else %>
     <li class="status <% if d['door_open'].to_i == 1 %>open<% else %>closed<% end %>">
@@ -40,7 +40,7 @@
       <% else %>
         geschlossen
       <% end %>
-      <span class="time"><%= Time.at(d['timestamp']).localtime.strftime("%Y-%m-%d %H:%M") %></span>
+      <span class="time"><%= Time.parse(d['timestamp'] + "UTC").localtime.strftime("%Y-%m-%d %H:%M") %></span>
     <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
There is a new (breaking) specification for the space API. Since then the metameutestatus (and it's chaotikum fork) are no longer compliant. The guys behind spaceapi have asked us to fix that... so here goes nothing.

Changes:
- Api changed to 0.13
- The open/closed state and the icons as well as lastchange are now in the state object
- contact needs an email because otherwise it can not be referenced in the issue_report_channels
- issue_report_channels had to be added
- the object in feeds have to be named, there is no object for the status-feed so it has been removed
- lat, long, address are now in a location object.